### PR TITLE
Removed libc6-compat library from backend dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,5 @@
 FROM node:slim AS base
 
-RUN apk add --no-cache libc6-compat
-
 WORKDIR /app
 
 FROM base AS deps
@@ -35,7 +33,7 @@ RUN addgroup --system --gid 1001 nodejs \
 COPY --from=builder /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
-COPY --from=builder /app/server.js ./server.js   # standalone entrypoint
+COPY --from=builder /app/server.js ./server.js
 
 USER nextjs
 


### PR DESCRIPTION
libc6-compat is no longer needed when using node:slim version.