### PR TITLE
Added ingress and liveness route

### DIFF
--- a/apps/edwardnafornita-com/src/app/api/healthz/route.ts
+++ b/apps/edwardnafornita-com/src/app/api/healthz/route.ts
@@ -1,0 +1,3 @@
+export async function GET() {
+  return new Response('ok', { status: 200 });
+}

--- a/k8s/base/ingress.yaml
+++ b/k8s/base/ingress.yaml
@@ -1,0 +1,25 @@
+# ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: edwardnafornita-com
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    cert-manager.io/cluster-issuer: cloudflare-issuer
+    traefik.ingress.kubernetes.io/router.tls: "true"
+spec:
+  tls:
+    - hosts:
+        - edwardnafornita.com
+      secretName: edwardnafornita-com-tls
+  rules:
+    - host: edwardnafornita.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: edwardnafornita-com
+                port:
+                  number: 80

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - service.yaml
+  - ingress.yaml
 
 commonLabels:
   owner: edwardnafornita


### PR DESCRIPTION
**Description**

- Adds a `ingress.yaml` for Argo to pick up the desired ingress and deploy to the proper URL with TLS certificates
- Adds the missing liveness probe route that keeps crashing the pods